### PR TITLE
Fix false alarm issue with Inefficient Regular Expression Complexity in nth-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react-bootstrap": "^2.2.1",
     "react-dom": "^17.0.2",
     "react-intersection-observer": "^8.33.1",
-    "react-scripts": "5.0.0",
     "react-scroll": "^1.8.6",
     "sass": "^1.49.9",
     "typewriter-effect": "^2.18.2",
@@ -47,5 +46,7 @@
       "last 1 safari version"
     ]
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "react-scripts": "5.0.0"
+  }
 }


### PR DESCRIPTION
This PR fixes a dependabots check: https://github.com/Ekown/ekown.github.io/security/dependabot/1

Although according to a discussion [here](https://github.com/facebook/create-react-app/issues/11174), it is probably a false alarm since react-scripts would not be used in a production environment (in this case at least).

This issue can be fixed/removed by placing the `react-scripts` in the `devDependencies` section in `package.json`.